### PR TITLE
Fix duplicate gestureClassifier import

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -20,9 +20,7 @@ import {
     detectFaces,
 } from './modules/multiFaceDetector.js';
 import { createClassifierMap, DEFAULT_THRESH_MBPRO } from './modules/gestureClassifier.js';
-import { createClassifierMap } from './modules/gestureClassifier.js';
 import { mbp2020Defaults } from './modules/mbp2020Defaults.js';
- main
 
 /*****************************************************************
  *  3)  HAND
@@ -99,11 +97,9 @@ async function setup() {
     faceClassifier = createClassifierMap({
         deepDebug: DEEP_DEBUG,
         yawThresh: DEFAULT_THRESH_MBPRO,
-        pitchThresh: DEFAULT_THRESH_MBPRO
-
+        pitchThresh: DEFAULT_THRESH_MBPRO,
         ...mbp2020Defaults,
-        deepDebug: DEEP_DEBUG
-main
+        deepDebug: DEEP_DEBUG,
     });
 
     handDetector = await loadHandDetector();


### PR DESCRIPTION
## Summary
- remove duplicate `createClassifierMap` import
- clean merge artifact from setup

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `npm test` *(fails: Missing script `test`)*