### PR TITLE
Add motion-aware calibrator

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,9 @@
   <link rel="stylesheet" href="/src/style.css" />
 </head>
 <body class="bg-neutral-900 text-white flex flex-col items-center gap-4 min-h-screen p-4">
+  <div id="calibBar"><div id="calibDot"></div></div>
+  <div id="toast" class="toast" style="display:none"></div>
+  <div id="devInfo" class="dev-info" style="display:none"></div>
 
   <!-- Attractor -->
   <div id="attractor" class="animate-pulse flex flex-col items-center gap-4 text-center">

--- a/src/modules/calibrator.js
+++ b/src/modules/calibrator.js
@@ -1,0 +1,93 @@
+export function createCalibrator(options = {}) {
+    const cfg = Object.assign({
+        stillThresh: 0.03,
+        stillFrames: 15,
+        capFrames: 30,
+    }, options);
+
+    let state = 'WAIT_STABLE';
+    let baseYaw = 0, basePitch = 0;
+    let stillCount = 0;
+    let capCount = 0;
+    let sumYaw = 0, sumPitch = 0;
+    let active = false;
+
+    function start(yaw = 0, pitch = 0) {
+        baseYaw = yaw;
+        basePitch = pitch;
+        stillCount = 0;
+        capCount = 0;
+        sumYaw = 0;
+        sumPitch = 0;
+        state = 'WAIT_STABLE';
+        active = true;
+    }
+
+    function reset() {
+        state = 'WAIT_STABLE';
+        stillCount = 0;
+        capCount = 0;
+        sumYaw = 0;
+        sumPitch = 0;
+        active = false;
+    }
+
+    function update(yaw, pitch) {
+        if (!active) {
+            const dy = yaw - baseYaw;
+            const dp = pitch - basePitch;
+            const dist = Math.hypot(dy, dp);
+            return { state, still: dist < cfg.stillThresh };
+        }
+
+        const dy = yaw - baseYaw;
+        const dp = pitch - basePitch;
+        const dist = Math.hypot(dy, dp);
+
+        if (state === 'WAIT_STABLE') {
+            if (dist < cfg.stillThresh) {
+                stillCount++;
+                if (stillCount >= cfg.stillFrames) {
+                    state = 'CAPTURING';
+                    capCount = 0;
+                    sumYaw = 0;
+                    sumPitch = 0;
+                }
+            } else {
+                stillCount = 0;
+                baseYaw = yaw;
+                basePitch = pitch;
+            }
+            return { state, progress: stillCount / cfg.stillFrames, still: dist < cfg.stillThresh };
+        }
+
+        if (state === 'CAPTURING') {
+            if (dist < cfg.stillThresh) {
+                sumYaw += yaw;
+                sumPitch += pitch;
+                capCount++;
+                if (capCount >= cfg.capFrames) {
+                    baseYaw = sumYaw / capCount;
+                    basePitch = sumPitch / capCount;
+                    state = 'READY';
+                    active = false;
+                    return { state, baseline: { yaw: baseYaw, pitch: basePitch }, progress: 1, still: true };
+                }
+            } else {
+                start(yaw, pitch);
+            }
+            return { state, progress: capCount / cfg.capFrames, still: dist < cfg.stillThresh };
+        }
+
+        return { state, baseline: { yaw: baseYaw, pitch: basePitch }, progress: 1, still: dist < cfg.stillThresh };
+    }
+
+    return {
+        start,
+        update,
+        reset,
+        get active() { return active; },
+        get state() { return state; },
+        get baseline() { return { yaw: baseYaw, pitch: basePitch }; }
+    };
+}

--- a/src/modules/calibratorUI.js
+++ b/src/modules/calibratorUI.js
@@ -1,0 +1,44 @@
+export function initCalibratorUI() {
+    const bar = document.getElementById('calibBar');
+    const dot = document.getElementById('calibDot');
+    const toastEl = document.getElementById('toast');
+    const infoEl = document.getElementById('devInfo');
+    const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+
+    function beep() {
+        const osc = audioCtx.createOscillator();
+        const gain = audioCtx.createGain();
+        osc.type = 'sine';
+        osc.frequency.value = 880;
+        osc.connect(gain);
+        gain.connect(audioCtx.destination);
+        osc.start();
+        gain.gain.setValueAtTime(0.1, audioCtx.currentTime);
+        gain.gain.exponentialRampToValueAtTime(0.0001, audioCtx.currentTime + 0.2);
+        osc.stop(audioCtx.currentTime + 0.2);
+    }
+
+    function showToast(msg) {
+        if (!toastEl) return;
+        toastEl.textContent = msg;
+        toastEl.style.display = 'block';
+        setTimeout(() => {
+            toastEl.style.display = 'none';
+        }, 1500);
+    }
+
+    return {
+        update(progress, still) {
+            if (bar) bar.style.width = `${Math.round(progress * 100)}%`;
+            if (dot) dot.style.background = still ? 'limegreen' : 'red';
+        },
+        showToast,
+        beep,
+        updateInfo(text) {
+            if (infoEl) {
+                infoEl.textContent = text;
+                infoEl.style.display = text ? 'block' : 'none';
+            }
+        }
+    };
+}

--- a/src/modules/gestureClassifier.js
+++ b/src/modules/gestureClassifier.js
@@ -176,12 +176,18 @@ export function createClassifierMap(options = {}) {
         return gestures;
     }
 
-    function calibrate(faceId = null) {
+    function calibrate(faceId = null, baseline = null) {
         if (faceId !== null) {
             const s = state.get(faceId);
-            if (s) s.baseline = { yaw: s.smoothYaw, pitch: s.smoothPitch };
+            if (s) {
+                if (baseline) s.baseline = { yaw: baseline.yaw, pitch: baseline.pitch };
+                else s.baseline = { yaw: s.smoothYaw, pitch: s.smoothPitch };
+            }
         } else {
-            state.forEach(s => { s.baseline = { yaw: s.smoothYaw, pitch: s.smoothPitch }; });
+            state.forEach(s => {
+                if (baseline) s.baseline = { yaw: baseline.yaw, pitch: baseline.pitch };
+                else s.baseline = { yaw: s.smoothYaw, pitch: s.smoothPitch };
+            });
         }
     }
 

--- a/src/style.css
+++ b/src/style.css
@@ -111,4 +111,55 @@ canvas {
     border-radius: 0.25rem;
     white-space: pre-wrap;
 }
+
+/* --- Calibrator UI --- */
+#calibBar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 4px;
+    width: 0%;
+    background: limegreen;
+    transition: width 0.1s linear;
+    z-index: 1000;
+}
+
+#calibDot {
+    position: fixed;
+    top: 6px;
+    left: 50%;
+    width: 12px;
+    height: 12px;
+    margin-left: -6px;
+    border-radius: 50%;
+    background: red;
+    pointer-events: none;
+    z-index: 1001;
+}
+
+.toast {
+    position: fixed;
+    bottom: 2rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(0,0,0,0.6);
+    padding: 0.5rem 1rem;
+    border-radius: 0.25rem;
+    font-size: 0.9rem;
+    pointer-events: none;
+    z-index: 1001;
+}
+
+.dev-info {
+    position: fixed;
+    top: 2rem;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 0.75rem;
+    background: rgba(0,0,0,0.5);
+    padding: 2px 4px;
+    border-radius: 0.25rem;
+    pointer-events: none;
+    z-index: 1001;
+}
   


### PR DESCRIPTION
## Summary
- build a simple calibration FSM for face neutral pose
- expose calibration UI with progress bar and toast
- inject averaged baseline into gesture classifier
- skip gesture detection until calibrated

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*