### PR TITLE
Fix gesture amplitude check and calibrator start logic

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -184,7 +184,7 @@ function tick(now) {
             calibrators.set(id, cal);
         }
 
-        if (pendingCalib || (cal.state !== 'READY' && !cal.active)) {
+        if ((pendingCalib && cal.state !== 'READY') || (cal.state === 'WAIT_STABLE' && !cal.active)) {
             cal.start(yaw, pitch);
             if (pendingCalib) calibUI?.showToast('Hold still…');
         }

--- a/src/modules/gestureClassifier.js
+++ b/src/modules/gestureClassifier.js
@@ -129,8 +129,7 @@ export function createClassifierMap(options = {}) {
                 break;
 
               case 'nod_started': {
-                const diff = dpitch * s.nodDir;
-                const crossed = diff < -cfg.pitchAmp;
+                const crossed = Math.abs(dpitch) > cfg.pitchAmp;
                 if (((s.nodDir < 0 && pitchDot > cfg.pVel) ||
                      (s.nodDir > 0 && pitchDot < -cfg.pVel)) &&
                     crossed &&
@@ -155,8 +154,7 @@ export function createClassifierMap(options = {}) {
               s.shakeT0       = now;
             }
             if (s.shakeSwinging) {
-              const diff = dyaw * s.shakeDir;
-              const crossed = diff < -cfg.yawAmp;
+              const crossed = Math.abs(dyaw) > cfg.yawAmp;
               if (Math.sign(yawDot) === -s.shakeDir &&
                   Math.abs(yawDot) > cfg.yVel &&
                   crossed) {


### PR DESCRIPTION
## Summary
- correct amplitude detection in gesture classifier
- tweak calibrator start condition so it doesn't restart repeatedly

## Testing
- `npm run lint` *(fails: Missing script)*