### PR TITLE
Extend question and QR display phases

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,13 +13,20 @@
 
   <!-- Attractor -->
   <div id="attractor" class="animate-pulse flex flex-col items-center gap-4 text-center">
+    <div id="startCircle" class="start-circle"></div>
     <img src="/img/shield.svg" class="w-24 h-24" />
-    <h1 class="text-3xl font-bold">Public Security Quiz</h1>
-    <p class="text-sm opacity-80">Step into the frame to begin</p>
+    <h1 class="text-3xl font-bold">Schau in die Kamera &amp; nicke, um zu starten</h1>
+    <p class="text-sm opacity-80">Datenschutz-Hinweis</p>
   </div>
 
   <!-- Question + countdown -->
-  <h1 id="q" class="hidden text-2xl font-semibold text-center"></h1>
+  <div id="questionCard" class="hidden question-card relative flex flex-col items-center gap-2">
+    <svg id="timerRing" class="timer-ring" width="140" height="140">
+      <circle cx="70" cy="70" r="64" />
+    </svg>
+    <h1 id="q" class="text-2xl font-semibold text-center"></h1>
+    <p class="text-sm opacity-80">Nicken = Ja | Kopf schütteln = Nein</p>
+  </div>
   <div id="clock" class="hidden text-lg text-center"></div>
 
   <!-- Live vote chart -->
@@ -28,6 +35,12 @@
   <div id="scoreboard" class="hidden flex gap-6 text-xl font-semibold mt-2">
     <div>Yes: <span id="countYes">0</span></div>
     <div>No: <span id="countNo">0</span></div>
+  </div>
+
+  <!-- Vote feedback overlay -->
+  <div id="voteFeedback" class="vote-feedback hidden flex flex-col items-center">
+    <div id="voteIcon" class="text-6xl">👍</div>
+    <div class="text-lg mt-2">Deine Stimme wurde gezählt</div>
   </div>
 
   <!-- On‐screen YES/NO debug indicator -->

--- a/src/main.js
+++ b/src/main.js
@@ -101,6 +101,17 @@ function showGesture(g) {
     setTimeout(() => (el.style.display = 'none'), 800);
 }
 
+function showVoteFeedback(g) {
+    const el = document.getElementById('voteFeedback');
+    const icon = document.getElementById('voteIcon');
+    if (!el || !icon) return;
+    icon.textContent = g === 'yes' ? '👍' : '👎';
+    el.classList.remove('hidden');
+    setTimeout(() => {
+        el.classList.add('hidden');
+    }, 1000);
+}
+
 /**
  * Register & log a yes/no vote
  */
@@ -110,6 +121,7 @@ function registerVote(gesture) {
         lastVoteTime[gesture] = now;
         sendVote(gesture);
         showGesture(gesture);
+        showVoteFeedback(gesture);
         appendLog(`Gesture accepted: ${gesture}`);
     } else {
         appendLog(`Gesture ignored (cooldown): ${gesture}`);
@@ -202,13 +214,13 @@ function tick(now) {
         // if user clicked calibrate or hasn't calibrated yet
         if ((pendingCalib && cal.state !== 'READY') || (cal.state === 'WAIT_STABLE' && !cal.active)) {
             cal.start(yaw, pitch);
-            if (pendingCalib) calibUI?.showToast('Hold still…');
+            if (pendingCalib) calibUI?.showToast('Bitte ruhig halten…');
         }
 
         const res = cal.update(yaw, pitch);
         if (res.baseline) {
             faceClassifier.calibrate(id, res.baseline);
-            calibUI?.showToast('Calibration complete');
+            calibUI?.showToast('✅ Kalibrierung fertig – los geht\u2019s!');
             calibUI?.beep();
         }
 
@@ -232,7 +244,7 @@ function tick(now) {
         firstSeen = 0;
         if (!lostSince) lostSince = performance.now();
         if (performance.now() - lostSince > 1000) {
-            calibUI?.showToast('Face lost — look at camera to resume.');
+            calibUI?.showToast('Gesicht verloren – erneut ausrichten');
             lostSince = performance.now();
         }
     }

--- a/src/modules/calibratorUI.js
+++ b/src/modules/calibratorUI.js
@@ -21,10 +21,15 @@ export function initCalibratorUI() {
     function showToast(msg) {
         if (!toastEl) return;
         toastEl.textContent = msg;
+        toastEl.style.opacity = '1';
         toastEl.style.display = 'block';
         setTimeout(() => {
-            toastEl.style.display = 'none';
-        }, 1500);
+            toastEl.style.opacity = '0';
+            setTimeout(() => {
+                toastEl.style.display = 'none';
+                toastEl.style.opacity = '1';
+            }, 300);
+        }, 1000);
     }
 
     return {

--- a/src/modules/qrGenerator.js
+++ b/src/modules/qrGenerator.js
@@ -5,8 +5,9 @@ export function showQR(link) {
     if (!container) return;
     container.classList.remove('hidden');
     container.innerHTML = `
-    <p class="text-center">Scan to discuss further:</p>
+    <h2 class="text-center text-xl mb-2">Scanne &amp; chatte weiter</h2>
     <img src="https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(link)}" alt="QR Code" />
+    <p class="text-center text-sm mt-1">${link}</p>
   `;
 }
 

--- a/src/modules/questionRotator.js
+++ b/src/modules/questionRotator.js
@@ -2,6 +2,9 @@ import { set, get } from '../store.js';
 import { showQR, hideQR } from './qrGenerator.js';
 import { stopVoteMeter } from './voteTally.js';
 
+const QUESTION_TIME_MS = 60_000;  // 1 minute per question
+const QR_TIME_MS = 60_000;        // 1 minute for the QR screen
+
 let questions = [];
 
 let currentIndex = 0;
@@ -29,45 +32,58 @@ function showQuestion(question) {
     set({
         mode: 'idle',
         question,
-        deadline: Date.now() + 60_000,  // 60s
+        deadline: Date.now() + QUESTION_TIME_MS,
         tally: { yes: 0, no: 0 },
     });
 
     updateQuestionUI(question);
-    startCountdown(60);
+    startCountdown(QUESTION_TIME_MS / 1000, showQrPhase, true);
 }
 
 // Simple countdown in seconds
-function startCountdown(seconds) {
+function startCountdown(seconds, onDone, showRing = true) {
     const clockEl = document.getElementById('clock');
+    const ring = document.getElementById('timerRing');
     clockEl.classList.remove('hidden');
+    if (ring) {
+        ring.style.animation = 'none';
+        // force reflow
+        ring.getBoundingClientRect();
+        if (showRing) {
+            ring.style.animation = `countdown ${seconds}s linear forwards`;
+        }
+    }
 
     clearInterval(timerHandle);
     timerHandle = setInterval(() => {
         const remaining = Math.floor((get().deadline - Date.now()) / 1000);
         if (remaining <= 0) {
             clearInterval(timerHandle);
-            // time’s up → show QR, freeze bars
-            set({ mode: 'qr' });
-            freezeUI();
-            // after some time, load next question
-            setTimeout(nextQuestion, 5000);
+            if (typeof onDone === 'function') onDone();
         } else {
-            clockEl.textContent = `Time Left: ${remaining}s`;
+            clockEl.textContent = `${remaining}s`;
         }
     }, 250);
 }
 
+function showQrPhase() {
+    set({ mode: 'qr', deadline: Date.now() + QR_TIME_MS });
+    freezeUI();
+    startCountdown(QR_TIME_MS / 1000, nextQuestion, false);
+}
+
 function freezeUI() {
-    // Hide countdown
+    // Hide question card and timer ring
+    const ring = document.getElementById('timerRing');
+    if (ring) ring.style.animation = 'none';
+    const card = document.getElementById('questionCard');
+    if (card) card.classList.add('hidden');
+
+    // Show QR and countdown text
     const clockEl = document.getElementById('clock');
-    clockEl.classList.add('hidden');
-    // Show QR code
-    showQR('https://example.com/discussion');  // or some dynamic link
-    // Possibly stop vote meter or freeze it
-    // In this example, let's keep it displayed but not destroyed
-    // If you wanted to hide it, you could do:
-    // stopVoteMeter();
+    clockEl.classList.remove('hidden');
+    showQR('https://example.com/discussion');
+    // Optionally stop vote meter etc.
 }
 
 function nextQuestion() {
@@ -79,6 +95,8 @@ function nextQuestion() {
 
 function updateQuestionUI(q) {
     const qEl = document.getElementById('q');
+    const card = document.getElementById('questionCard');
     qEl.textContent = q;
     qEl.classList.remove('hidden');
+    if (card) card.classList.remove('hidden');
 }

--- a/src/style.css
+++ b/src/style.css
@@ -202,6 +202,7 @@ canvas {
     z-index: 1001;
     box-shadow: 0 2px 8px rgba(0,0,0,0.5); /* Added shadow */
     border: 1px solid rgba(255,255,255,0.1); /* Subtle border */
+    transition: opacity 0.3s;
 }
 
 .dev-info {
@@ -216,5 +217,77 @@ canvas {
     pointer-events: none;
     z-index: 1001;
     box-shadow: 0 1px 3px rgba(0,0,0,0.4); /* Added shadow */
+}
+
+/* --- Attractor pulse circle --- */
+#startCircle {
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    border: 3px solid rgba(255,255,255,0.6);
+    animation: pulseCircle 2s infinite;
+}
+
+@keyframes pulseCircle {
+    0% { transform: scale(0.9); opacity: 0.7; }
+    50% { transform: scale(1.1); opacity: 1; }
+    100% { transform: scale(0.9); opacity: 0.7; }
+}
+
+/* --- Question card and timer ring --- */
+#questionCard {
+    position: relative;
+    padding: 1rem 2rem;
+    border: 2px solid rgba(255,255,255,0.3);
+    border-radius: 0.5rem;
+    background: rgba(0,0,0,0.5);
+}
+
+#timerRing {
+    position: absolute;
+    top: -10px;
+    left: -10px;
+    width: 140px;
+    height: 140px;
+    transform: rotate(-90deg);
+    pointer-events: none;
+}
+
+#timerRing circle {
+    stroke: white;
+    stroke-width: 4;
+    fill: none;
+    stroke-dasharray: 402;
+    stroke-dashoffset: 402;
+}
+
+@keyframes countdown {
+    to { stroke-dashoffset: 0; }
+}
+
+/* --- Vote feedback overlay --- */
+.vote-feedback {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(0,0,0,0.7);
+    padding: 1rem 2rem;
+    border-radius: 0.5rem;
+    z-index: 1001;
+    text-align: center;
+}
+
+/* --- QR container --- */
+#qrContainer {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(0,0,0,0.8);
+    padding: 1rem;
+    border-radius: 0.5rem;
+    z-index: 1001;
+    text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- update `questionRotator` to keep questions and QR code on screen for one minute each
- show a countdown during the QR phase before advancing

## Testing
- `npm run build` *(fails: cannot find optional rollup dependency)*