### PR TITLE
Fix calibrator UI syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,25 +8,13 @@
 </head>
 <body class="bg-neutral-900 text-white flex flex-col items-center gap-4 min-h-screen p-4">
   <div id="calibOverlay" class="calib-overlay hidden">
-
+    <svg id="calibRing" class="calib-ring" width="120" height="120">
+      <circle cx="60" cy="60" r="54"></circle>
+    </svg>
+    <div id="calibText" class="mt-2">Bitte ruhig halten…</div>
   </div>
   <div id="toast" class="toast" style="display:none"></div>
   <div id="devInfo" class="dev-info" style="display:none"></div>
-  <!-- Calibration overlay -->
-  <div id="calibOverlay" class="calib-overlay hidden">
-    <svg id="calibRing" width="120" height="120">
-      <circle id="calibProgress" cx="60" cy="60" r="54" />
-    </svg>
-    <div id="calibText" class="calib-text">Bitte ruhig halten…</div>
-
-  <div id="calibOverlay" class="calib-overlay hidden">
-    <svg width="120" height="120" class="progress-ring">
-      <circle cx="60" cy="60" r="54" class="bg" />
-      <circle id="calibRing" cx="60" cy="60" r="54" class="fg" />
-    </svg>
-    <div id="calibMsg" class="calib-msg">Bitte ruhig halten…</div>
-
-  </div>
 
   <!-- Attractor -->
   <div id="attractor" class="animate-pulse flex flex-col items-center gap-4 text-center">
@@ -57,7 +45,6 @@
   <!-- Vote feedback overlay -->
   <div id="voteFeedback" class="vote-feedback hidden flex flex-col items-center">
     <div id="voteIcon" class="text-6xl">👍</div>
-
     <div class="text-lg mt-2">Deine Stimme wurde gezählt</div>
   </div>
 

--- a/src/modules/calibratorUI.js
+++ b/src/modules/calibratorUI.js
@@ -1,22 +1,18 @@
 export function initCalibratorUI() {
-
-
-  
+    const overlay = document.getElementById('calibOverlay');
+    const ringEl = document.getElementById('calibRing');
+    const circle = ringEl ? ringEl.querySelector('circle') : null;
+    const textEl = document.getElementById('calibText');
     const toastEl = document.getElementById('toast');
     const infoEl = document.getElementById('devInfo');
-    const overlay = document.getElementById('calibOverlay');
-    const ring = document.getElementById('calibRing');
-    const msgEl = document.getElementById('calibMsg');
-
-    const textEl = document.getElementById('calibText');
- (r=56)
-
-
     const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
     let circumference = 0;
-
-
+    if (circle) {
+        const r = parseFloat(circle.getAttribute('r')) || 0;
+        circumference = 2 * Math.PI * r;
+        circle.style.strokeDasharray = circumference;
+        circle.style.strokeDashoffset = circumference;
     }
 
     function beep() {
@@ -44,96 +40,17 @@ export function initCalibratorUI() {
                 toastEl.style.opacity = '1';
             }, 300);
         }, 1000);
-
     }
-
-    function showOverlay() {
-        if (overlay) overlay.classList.remove('hidden');
-    }
-
-    function hideOverlay() {
-        if (overlay) overlay.classList.add('hidden');
-    }
-
-    function setText(msg) {
-        if (textEl) textEl.textContent = msg;
-    }
-
-    function updateRing(p) {
-        if (ring) {
-            const max = 339; // circumference
-            ring.style.strokeDashoffset = max - max * p;
-        }
 
     function showOverlay(show) {
         if (!overlay) return;
         overlay.classList.toggle('hidden', !show);
     }
 
-    function update(progress, still) {
-        if (bar) bar.style.width = `${Math.round(progress * 100)}%`;
-        if (dot) dot.style.background = still ? 'limegreen' : 'red';
-        if (ring) {
-            const circ = 339.292; // 2*pi*r
-            ring.style.strokeDashoffset = circ * (1 - progress);
-        }
-    }
-
-    return {
-        update,
-        showOverlay,
-
-
-    }
-
-    function show() {
-        if (overlay) overlay.style.display = 'flex';
-        if (textEl) textEl.textContent = 'Bitte ruhig halten…';
-    }
-
-    function hide() {
-        if (overlay) overlay.style.display = 'none';
-        if (ringCircle) ringCircle.style.strokeDashoffset = circumference;
-        if (textEl) textEl.textContent = '';
-
-
-    }
-
-    return {
-        update(progress, still) {
-            if (bar) bar.style.width = `${Math.round(progress * 100)}%`;
-            if (dot) dot.style.background = still ? 'limegreen' : 'red';
-            updateRing(progress);
-
-            if (ring) {
-                ring.style.strokeDashoffset = circumference * (1 - progress);
-            }
-            if (overlay) {
-                overlay.classList.toggle('hidden', progress >= 1);
-            }
-            if (textEl) {
-                textEl.textContent = 'Bitte ruhig halten…';
-            show();
-            if (ringCircle) {
-                ringCircle.style.strokeDashoffset = circumference * (1 - progress);
-                ringCircle.style.stroke = still ? 'limegreen' : 'tomato';
-            }
-
-        },
-        show,
-        hide,
-
-        showToast,
-        showOverlay,
-        hideOverlay,
-        setText,
-        beep,
-        updateInfo(text) {
-            if (infoEl) {
-                infoEl.textContent = text;
-                infoEl.style.display = text ? 'block' : 'none';
-            }
-            if (msgEl) msgEl.textContent = text;
+    function update(progress = 0, still = false) {
+        if (circle) {
+            const offset = circumference - circumference * progress;
+            circle.style.strokeDashoffset = offset;
         }
         if (textEl) textEl.style.color = still ? 'limegreen' : 'red';
     }

--- a/src/style.css
+++ b/src/style.css
@@ -167,6 +167,19 @@ canvas {
 }
 
 
+/* --- Calibration overlay --- */
+.calib-overlay {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0,0,0,0.4);
+    z-index: 1001;
+}
+
+
 
 
 .calib-ring {


### PR DESCRIPTION
## Summary
- restore clean calibrator UI implementation
- revert calibration overlay markup
- add missing `.calib-overlay` style

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `npm run dev` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*