### PR TITLE
Add nod guard for shake start

### DIFF
--- a/src/modules/gestureClassifier.js
+++ b/src/modules/gestureClassifier.js
@@ -255,7 +255,10 @@ export function createClassifierMap(options = {}) {
             /* ---------------------------------------------------------------
                NO (shake) FSM
                ---------------------------------------------------------------*/
-            if (!s.shakeSwinging && Math.abs(yawDot) > cfg.yVel && Math.abs(dyaw) > cfg.yawAmp) {
+            if (!s.shakeSwinging &&
+                Math.abs(yawDot) > cfg.yVel &&
+                Math.abs(dyaw)  > cfg.yawAmp &&
+                Math.abs(dpitch) < cfg.guardPitch) {
                 s.shakeSwinging = true;
                 s.shakeDir = Math.sign(yawDot);
                 s.shakeT0 = nowMs;


### PR DESCRIPTION
## Summary
- avoid shake detection when pitch angle exceeds guard threshold

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*