### PR TITLE
Add demo video fallback

### DIFF
--- a/public/sample.mp4
+++ b/public/sample.mp4
@@ -1,0 +1,1 @@
+sample placeholder

--- a/src/modules/camera.js
+++ b/src/modules/camera.js
@@ -1,35 +1,44 @@
 export async function initCamera(width = 1280, height = 720) {
-    let stream;
-    try {
-        stream = await navigator.mediaDevices.getUserMedia({
-            video: { width, height, facingMode: 'user' },
-            audio: false,
-        });
-    } catch (err) {
-        alert('Camera access denied or unavailable. Please enable the camera and reload.');
-        console.error("Error accessing camera:", err); // Log error for debugging
-        throw err; // Re-throw the error for the caller to handle
-    }
-
     const wrap = document.createElement('div');
-    wrap.className = 'camera-wrap'; // Added class for potential styling
+    wrap.className = 'camera-wrap';
     wrap.style.position = 'relative';
     wrap.style.display = 'inline-block';
     wrap.style.opacity = '0';
-    wrap.style.transition = 'opacity 1s ease-in-out'; // Smoother transition
+    wrap.style.transition = 'opacity 1s ease-in-out';
 
     const video = document.createElement('video');
-    video.setAttribute('playsinline', ''); // For iOS Safari and inline playback
-    video.setAttribute('autoplay', '');   // Ensure autoplay
-    video.setAttribute('muted', '');      // Mute audio to allow autoplay in most browsers
+    video.setAttribute('playsinline', '');
+    video.setAttribute('autoplay', '');
+    video.setAttribute('muted', '');
 
     const canvas = document.createElement('canvas');
     canvas.style.position = 'absolute';
     canvas.style.inset = '0';
     canvas.style.pointerEvents = 'none';
 
-    video.srcObject = stream;
-    const [videoTrack] = stream.getVideoTracks();
+    let stream;
+    let videoTrack;
+    try {
+        stream = await navigator.mediaDevices.getUserMedia({
+            video: { width, height, facingMode: 'user' },
+            audio: false,
+        });
+        video.srcObject = stream;
+        [videoTrack] = stream.getVideoTracks();
+    } catch (err) {
+        console.error('Error accessing camera:', err);
+        const toastEl = document.getElementById('toast');
+        if (toastEl) {
+            toastEl.textContent = 'Demo mode: using sample video.';
+            toastEl.style.display = 'block';
+            setTimeout(() => { toastEl.style.display = 'none'; }, 3000);
+        } else {
+            alert('Camera unavailable. Demo mode enabled.');
+        }
+        video.src = '/sample.mp4';
+        video.loop = true;
+    }
+
     await video.play();
 
     // fade video in when first frame arrives


### PR DESCRIPTION
## Summary
- handle camera permission errors and switch to a sample video
- show demo mode toast message
- add `public/sample.mp4` placeholder

## Testing
- `npm test` *(fails: no test script defined)*